### PR TITLE
Upgrade terraform-provider-cpln to v1.2.5

### DIFF
--- a/provider/go.mod
+++ b/provider/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/cloudflare/circl v1.6.1 // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
-	github.com/controlplane-com/terraform-provider-cpln v1.2.4 // indirect
+	github.com/controlplane-com/terraform-provider-cpln v1.2.5 // indirect
 	github.com/cyphar/filepath-securejoin v0.4.1 // indirect
 	github.com/deckarep/golang-set/v2 v2.5.0 // indirect
 	github.com/djherbis/times v1.5.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -321,8 +321,8 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 h1:q2hJAaP1k2wIvVRd/hEHD7lacgqrCPS+k8g1MndzfWY=
 github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
-github.com/controlplane-com/terraform-provider-cpln v1.2.4 h1:HDP13BvxI02Crroy+G0sFqbNbRMFTyDY//Spq/1P1h8=
-github.com/controlplane-com/terraform-provider-cpln v1.2.4/go.mod h1:3Vec8zaxTf7TtMdVw55hgbBFYiFTeGTc/QDl6aqb88I=
+github.com/controlplane-com/terraform-provider-cpln v1.2.5 h1:FReHCSCtC3gHiQFGzdbmOQH1Ma6CbjMDO76+Sr4WzfI=
+github.com/controlplane-com/terraform-provider-cpln v1.2.5/go.mod h1:WVjh5BrSpfy+aryNAxHAI/Adhp12PxKTV6viwXsBtIU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cyphar/filepath-securejoin v0.4.1 h1:JyxxyPEaktOD+GAnqIqTf9A8tHyAG22rowi7HkoSU1s=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
-	github.com/controlplane-com/terraform-provider-cpln v1.2.4
+	github.com/controlplane-com/terraform-provider-cpln v1.2.5
 	github.com/hashicorp/terraform-plugin-framework v1.15.0
 )
 

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -8,8 +8,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
-github.com/controlplane-com/terraform-provider-cpln v1.2.4 h1:HDP13BvxI02Crroy+G0sFqbNbRMFTyDY//Spq/1P1h8=
-github.com/controlplane-com/terraform-provider-cpln v1.2.4/go.mod h1:3Vec8zaxTf7TtMdVw55hgbBFYiFTeGTc/QDl6aqb88I=
+github.com/controlplane-com/terraform-provider-cpln v1.2.5 h1:FReHCSCtC3gHiQFGzdbmOQH1Ma6CbjMDO76+Sr4WzfI=
+github.com/controlplane-com/terraform-provider-cpln v1.2.5/go.mod h1:WVjh5BrSpfy+aryNAxHAI/Adhp12PxKTV6viwXsBtIU=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-cpln --kind=provider --target-bridge-version=latest --target-version=1.2.5 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-cpln from 1.2.4  to 1.2.5.
	Fixes #86
